### PR TITLE
Unexpected line return

### DIFF
--- a/stylesheets/term2.less
+++ b/stylesheets/term2.less
@@ -9,5 +9,9 @@
   .terminal {
     font-family: Menlo, Monaco, Inconsolata, monospace;
     font-size: 14px;
+
+    span {
+      white-space: pre;
+    }
   }
 }


### PR DESCRIPTION
![Screenshot](http://i.imgur.com/jRYFc1E.png)

Seems like it breaks line on `-` char. Nothing is wrong with the markup and there's no css `white-space` or `word-break` rules.
