### PR TITLE
Fix focus on tab selection

### DIFF
--- a/lib/TermView.coffee
+++ b/lib/TermView.coffee
@@ -102,6 +102,7 @@ class TermView extends View
   focus: ->
     @resizeToPane()
     @focusTerm()
+    super
 
   focusTerm: ->
     @term.element.focus()


### PR DESCRIPTION
When you select the terminal tab, the terminal should be ready to type
