### PR TITLE
Set cursor style to inverse of regular background and foreground colors.

### DIFF
--- a/lib/TermView.coffee
+++ b/lib/TermView.coffee
@@ -111,6 +111,16 @@ class TermView extends View
       @opts.fontSize or
       atom.config.get('editor.fontSize')
     ) + "px"
+    # Insert style for cursor.
+    [..., bg, fg] = @opts.colors.map (color) -> color.toHexString()
+    cursorStyleElement = $(
+      "<style>
+      .terminal-cursor {
+        background-color: #{fg};
+        color: #{bg};
+      }
+      </style>")
+    $(@term.element).prepend cursorStyleElement
 
   attachEvents: ->
     @resizeToPane = @resizeToPane.bind this

--- a/styles/term2.less
+++ b/styles/term2.less
@@ -18,10 +18,6 @@
       }
     }
 
-    .terminal-cursor {
-      background-color: #fff;
-    }
-
     span {
       white-space: pre;
     }


### PR DESCRIPTION
As raised in #177 and #189 , when using a white-on-black color scheme, the terminal cursor currently hides the text beneath it, since the terminal cursor's style is simply set to `background-color: #fff`.

This PR fixes this by applying the inverse color scheme (`background-color: #{fg}; color: #{bg}`) to the terminal cursor element, as shown in the screenshot below:

![screen shot 2015-10-08 at 5 02 24 pm](https://cloud.githubusercontent.com/assets/326631/10383030/eae8bc50-6dde-11e5-80f1-f4a97901d961.png)

This is based on the [`insertStyle`](https://github.com/chjj/term.js/blob/master/src/term.js#L713) method in term.js. Note that term.js is *not* calling `insertStyle` because [we pass in `useStyle: no` in the `Terminal` constructor](https://github.com/f/atom-term2/blob/master/lib/TermView.coffee#L53).