### PR TITLE
Fix focus problems by attaching to pane and pane item activation events.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -143,19 +143,12 @@ module.exports =
     splitTerm: (direction)->
       openPanesInSameSplit = atom.config.get 'term2.openPanesInSameSplit'
       termView = @createTermView()
-      termView.on "click", =>
-
-        # get focus in the terminal
-        # avoid double click to get focus
-        termView.term.element.focus()
-        termView.term.focus()
-
-        @focusedTerminal = termView
       direction = capitalize direction
 
       splitter = =>
         pane = activePane["split#{direction}"] items: [termView]
         activePane.termSplits[direction] = pane
+        @attachFocusEvents pane, pane.items[0], termView
         @focusedTerminal = [pane, pane.items[0]]
 
       activePane = atom.workspace.getActivePane()
@@ -164,6 +157,7 @@ module.exports =
         if activePane.termSplits[direction] and activePane.termSplits[direction].items.length > 0
           pane = activePane.termSplits[direction]
           item = pane.addItem termView
+          @attachFocusEvents pane, item, termView
           pane.activateItem item
           @focusedTerminal = [pane, item]
         else
@@ -175,6 +169,7 @@ module.exports =
       termView = @createTermView()
       pane = atom.workspace.getActivePane()
       item = pane.addItem termView
+      @attachFocusEvents pane, item, termView
       pane.activateItem item
 
     pipeTerm: (action)->
@@ -204,3 +199,13 @@ module.exports =
     serialize:->
       termViewsState = this.termViews.map (view)-> view.serialize()
       {termViews: termViewsState}
+
+    attachFocusEvents: (pane, item, termView)->
+      pane.onDidActivate =>
+        if pane.getActiveItem() == item
+          @focusedTerminal = termView
+          termView.focus()
+      pane.onDidChangeActiveItem (activeItem)=>
+        if activeItem == item
+          @focusedTerminal = termView
+          termView.focus()


### PR DESCRIPTION
This PR is intended to address focus problems described in #6 and #191 , namely that a terminal tab does *not* actually receive focus when the user clicks on it or switches to it via e.g. `cmd-k cmd-arrow`.

This PR works by binding to
* [`Pane.onDidActivate`](https://atom.io/docs/api/v1.0.19/Pane#instance-onDidActivate), i.e., when a pane receives focus;
* [`Pane.onDidChangeActiveItem`](https://atom.io/docs/api/v1.0.19/Pane#instance-onDidChangeActiveItem), i.e., when switching tabs within a pane.

When either of these happens, and the current visible tab on a pane is a terminal, we call `TermView.focus()`.

This PR also removes a previous binding on the click event, since it is now redundant.