### PR TITLE
Added cwd tag to Title customisation

### DIFF
--- a/lib/TermView.coffee
+++ b/lib/TermView.coffee
@@ -87,6 +87,7 @@ class TermView extends View
     hostName: os.hostname()
     platform: process.platform
     home    : process.env.HOME
+    cwd     : @opts.cwd
 
   getTitle: ->
     @vars = @titleVars()


### PR DESCRIPTION
Use `{{cwd}}` to display the current working dir in your terminal tab
